### PR TITLE
Fixed string vs number issue for calculation of temp offset for pagination in Audit Logs and Assets

### DIFF
--- a/src/frontend/src/app/asset-readings/assets/assets.component.ts
+++ b/src/frontend/src/app/asset-readings/assets/assets.component.ts
@@ -13,12 +13,12 @@ export class AssetsComponent implements OnInit {
 
   selectedAsset: any = 'Select'; // Selected asset object (asset_coded, asset_count)
   asset: any;
-  limit = 20;
-  offset = 0;
+  limit:number = 20;
+  offset:number = 0;
 
   page = 1;           // Default page is 1 in pagination
   recordCount = 0;    // Total no. of records during pagination
-  tempOffset = 0;     // Temporary offset during pagination
+  tempOffset:number = 0;     // Temporary offset during pagination
   totalPagesCount = 0;
   assets = [];
   assetsReadingsData = [];
@@ -91,9 +91,9 @@ export class AssetsComponent implements OnInit {
       this.limit = 20;
     }
     if (this.offset > 0) {
-      this.tempOffset = (((this.page) - 1) * this.limit) + this.offset;
+      this.tempOffset = ((this.page - 1) * this.limit) + this.offset;
     } else {
-      this.tempOffset = ((this.page) - 1) * this.limit;
+      this.tempOffset = (this.page - 1) * this.limit;
     }
     console.log('limit: ', this.limit);
     console.log('offset: ', this.offset);

--- a/src/frontend/src/app/number-input-debounce/number-input-debounce.component.ts
+++ b/src/frontend/src/app/number-input-debounce/number-input-debounce.component.ts
@@ -3,7 +3,7 @@ import {Observable} from 'rxjs/Rx';
 
 @Component({
     selector: 'number-input-debounce',
-    template: '<input class="input" appNumberOnly min="0" [max]="max" [placeholder]="placeholder" name="limit" [(ngModel)]="inputValue">',
+    template: '<input class="input" type="number" appNumberOnly min="0" [max]="max" [placeholder]="placeholder" name="limit" [(ngModel)]="inputValue">',
     styleUrls: ['./number-input-debounce.component.css']
 })
 export class NumberInputDebounceComponent {


### PR DESCRIPTION
1) Added `type=number` to fix pagination issue on audit logs and Assets